### PR TITLE
Use proper constructs to register bean programmatically

### DIFF
--- a/project/src/main/java/org/acme/ClassLoadingConfiguration.java
+++ b/project/src/main/java/org/acme/ClassLoadingConfiguration.java
@@ -1,11 +1,9 @@
 package org.acme;
 
-import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RegisterReflectionForBinding(MyAnnotatedClass.class)
 public class ClassLoadingConfiguration {
     @Bean
     public static ClassLoadingPostProcessor getClassLoadingPostProcessor() {


### PR DESCRIPTION
This commit fixes the use of component scan in a custom component, so that AOT can apply it a build-time and generate the necessary output.

Previously, the BeanFactoryPostProcessor callback interface was used which works on a prepared BeanFactory. AOT rather works on a BeanDefinitionRegistry and BeanDefinitions are those are translated in generated code that will ultimately create again the necessary bean instances.

You can see that the wrong callback is used as beanFactory does not allow you to register a bean definition. Registering a singleton is such that AOT cannot do anything about it. All we have is an instance and a type with no information whatsoever how the instance was created.

We don't want this post-processor to run again at runtime as it has done what's needed at build-time. One way to do that is to make it an AOT component so that the AOT engine knows whatever AOT contribution it returns matches what it would do at runtime without AOT. In the case of this commit, we return a `null` contribution as there's nothing extra to do.

Note that a better callback for this scenario would be to implement ImportBeanDefinitionRegistrar and add an `@Import` on the configuration class that it relates to. AOT would consider this to be part of AOT processing and will auto-exclude it. Unfortunately, such callback works at a level where an ApplicationContext is not available yet, and EntityScanner requires one.

Ultimately, using ClassPathScanningCandidateComponentProvider and the registrar callback is the idiomatic way of doing what the sample shows.